### PR TITLE
chore: tt_platform を infra-hub にリネームする

### DIFF
--- a/modules/repository/output.tf
+++ b/modules/repository/output.tf
@@ -37,6 +37,6 @@ output "github_pubnlic_repos" {
     {repo_name = "shiftb", visibility = "public" , archived = false , description = "", allow_auto_merge = false},
     {repo_name = "resume", visibility = "public" , archived = false , description = "", allow_auto_merge = false},
     {repo_name = "self_promotion_suga", visibility = "private" , archived = false , description = "", allow_auto_merge = false},
-    {repo_name = "tt_platform", visibility = "private" , archived = false , description = "", allow_auto_merge = false},
+    {repo_name = "infra-hub", visibility = "private" , archived = false , description = "", allow_auto_merge = false},
   ]
 }

--- a/takehiro1111/repository.tf
+++ b/takehiro1111/repository.tf
@@ -1,3 +1,11 @@
+// tt_platform から infra-hub へのリネームに追随する。
+// for_each のキーが repo_name のため、この宣言が無いと destroy → create（＝リポジトリ削除）になる。
+// apply 後は削除してよい
+moved {
+  from = github_repository.personal_repos["tt_platform"]
+  to   = github_repository.personal_repos["infra-hub"]
+}
+
 resource "github_repository" "personal_repos" {
   for_each = { for k, v in module.repo.github_pubnlic_repos : v.repo_name => v }
 


### PR DESCRIPTION
## 概要

GitHub 上でリポジトリ名を `tt_platform` から `infra-hub` に変更したため、Terraform の宣言を追随させる。

## 変更内容

- `modules/repository/output.tf`: `repo_name` を `infra-hub` に変更
- `takehiro1111/repository.tf`: **`moved` ブロックを追加**

## `moved` ブロックが必須である理由

`github_repository.personal_repos` の `for_each` は `repo_name` をキーにしている。

```hcl
for_each = { for k, v in module.repo.github_pubnlic_repos : v.repo_name => v }
```

そのため `repo_name` を書き換えるだけだと、Terraform には「`["tt_platform"]` が消え、`["infra-hub"]` が増えた」と見える。**plan は destroy → create になり、apply すると GitHub 上のリポジトリが削除される**（Issue・PR・スター・設定がすべて失われる）。

`moved` ブロックで state 上のキー移動を宣言することで、destroy を伴わずに追随できる。

```hcl
moved {
  from = github_repository.personal_repos["tt_platform"]
  to   = github_repository.personal_repos["infra-hub"]
}
```

`terraform state mv` を手で実行する方法もあるが、こちらはコードとしてレビューでき、tfaction の自動 apply とも整合するため `moved` を選んだ。

## レビュー時に必ず確認してほしいこと

**plan に `destroy` が含まれていないこと。** 含まれている場合はマージしないでください。想定される plan は次のいずれかです。

- `No changes`（`name` は既にリネーム済みのため）
- `moved` による state のキー移動のみ

## 補足

- `moved` ブロックは apply 後に削除して構いません（コメントにも記載）
- `terraform fmt -check` で `modules/repository/output.tf` と `_variables.tf` に差分が出ますが、**いずれも変更前から存在する既存の書式**です。周囲の行に合わせているため、本 PR では触っていません
- apply は実行していません

🤖 Generated with [Claude Code](https://claude.com/claude-code)